### PR TITLE
IterDomain-centric graph analysis

### DIFF
--- a/third_party/nvfuser/CMakeLists.txt
+++ b/third_party/nvfuser/CMakeLists.txt
@@ -46,6 +46,7 @@ list(APPEND NVFUSER_SRCS
     ${NVFUSER_SRCS_DIR}/index_compute.cpp
     ${NVFUSER_SRCS_DIR}/lower_index_compute.cpp
     ${NVFUSER_SRCS_DIR}/instrumentation.cpp
+    ${NVFUSER_SRCS_DIR}/id_e_graph.cpp
     ${NVFUSER_SRCS_DIR}/ir_base_nodes.cpp
     ${NVFUSER_SRCS_DIR}/ir_builder.cpp
     ${NVFUSER_SRCS_DIR}/ir_cloner.cpp
@@ -351,6 +352,7 @@ if(BUILD_TEST)
   list(APPEND JIT_TEST_SRCS ${NVFUSER_ROOT}/test/test_gpu_view.cpp)
   list(APPEND JIT_TEST_SRCS ${NVFUSER_ROOT}/test/test_gpu_transpose.cpp)
   list(APPEND JIT_TEST_SRCS ${NVFUSER_ROOT}/test/test_gpu_utils.cpp)
+  list(APPEND JIT_TEST_SRCS ${NVFUSER_ROOT}/test/test_gpu_id_e_graph.cpp)
   list(APPEND JIT_TEST_SRCS ${NVFUSER_ROOT}/test/test_gpu_indexing_ops.cpp)
   list(APPEND JIT_TEST_SRCS ${NVFUSER_ROOT}/test/test_gpu_indexing.cpp)
   list(APPEND JIT_TEST_SRCS ${NVFUSER_ROOT}/test/test_gpu_gather_ops.cpp)

--- a/third_party/nvfuser/csrc/id_e_graph.cpp
+++ b/third_party/nvfuser/csrc/id_e_graph.cpp
@@ -9,137 +9,22 @@ namespace jit {
 namespace fuser {
 namespace cuda {
 
-// A fixed-size tree-based union-find (aka disjoint-set) data structure using
-// subtree sizes instead of ranks.
-// cf. https://en.wikipedia.org/wiki/Disjoint-set_data_structure
-template <typename T>
-class UnionFind {
- public:
-  UnionFind(size_t size) {
-      value_.resize(size);
-      parent_.resize(size);
-      size_.resize(size);
-      // Initialize with all singletoons
-      for (size_t i = 0; i < size; ++i) {
-        parent_[i] = i;
-        size_[i] = 1;
-      }
-  }
-
-  UnionFind(std::vector<T> vals) : UnionFind(vals.size()) {
-    for (size_t i = 0; i < vals.size(); ++i) {
-      this->set_value(i, vals[i]);
-    }
-  }
-
-  UnionFind(std::unordered_set<T> vals) : UnionFind(vals.size()) {
-    size_t i = 0;
-    for (auto v: vals) {
-      this->set_value(i++, v);
-    }
-  }
-
-  void set_value(int pos, const T& val) {
-    value_[pos] = val;
-    val_to_pos_[val] = pos;
-  }
-  T get_value(int pos) {
-    TORCH_CHECK(
-      pos < value_.size(),
-      "Passed invalid position ", pos, " for UnionFind with ", value_.size(), " entries"
-    );
-    return value_[pos];
-  }
-
-  //! Insert the given value and return the new number of elements
-  size_t insert_value(const T& val) {
-    auto pos = parent_.size();
-    parent_.push_back(pos);
-    size_.push_back(1);
-    val_to_pos_[val] = pos;
-    value_.push_back(val);
-    return pos + 1;
-  }
-
-  //! Find the integer position of val
-  size_t get_position(const T& val) {
-    return val_to_pos_.at(val);
-  }
-
-  //! Get the integer index of the set from given position
-  size_t find_set(size_t v) {
-    if (v == parent_[v])
-      return v;
-    // Note that this step actually updates the tree to point directly to the
-    // root index, meaning subsequent look-ups will not need to recurse.
-    return parent_[v] = find_set(parent_[v]);
-  }
-  //! Get the integer index of the set for a given value
-  size_t find_set_from_value(T val) {
-    return find_set(get_position(val));
-  }
-
-  //! Get all elements in the set with given index (up to O(n^2))
-  std::vector<T> get_set(size_t idx) {
-    std::vector<T> s;
-    for (size_t i = 0; i < parent_.size(); ++i) {
-      if (find_set(i) == idx) {
-        s.push_back(value_.at(i));
-      }
-    }
-    return s;
-  }
-
-  //! Get a vector of all sets of values
-  std::vector<std::vector<T>> get_sets() {
-    std::vector<std::vector<T> > out;
-    for (size_t i = 0; i < parent_.size(); ++i) {
-      auto s = get_set(i);
-      if (s.size() > 0) {
-        out.push_back(s);
-      }
-    }
-    return out;
-  }
-
-  //! Merge two sets in the partition
-  void merge_sets(size_t a, size_t b) {
-    if (a != b) {
-      if (size_[a] < size_[b])
-        std::swap(a, b);
-      parent_[b] = a;
-      size_[a] += size_[b];
-    }
-  }
-  //! Merge the sets containing two given values
-  void merge_sets_from_values(T val_a, T val_b) {
-    auto a = find_set(get_position(val_a));
-    auto b = find_set(get_position(val_b));
-    merge_sets(a, b);
-  }
- private:
-  std::vector<T> value_;
-  std::unordered_map<T, size_t> val_to_pos_;
-  std::vector<size_t> parent_;
-  std::vector<int> size_;
-};
-
 IterDomainEGraph::IterDomainEGraph(const Fusion& fusion) {
   // Initialize a partition of all IterDomains in the Fusion, initially
   // containing all singleton classes.
-  std::vector<IterDomain*> all_ids;
-  std::unordered_set<Val*> all_extents; // Also track extents to find which are equivalent
-  for (auto v: fusion.vals()) {
+  for (auto v : fusion.vals()) {
     if (v->getValType() == ValType::IterDomain) {
       auto id = reinterpret_cast<IterDomain*>(v);
-      all_ids.push_back(id);
-      all_extents.insert(id->extent());
+      all_ids_.push_back(id);
+      all_extents_.insert(id->extent());
     }
   }
-  UnionFind<IterDomain*> id_partition(all_ids);
-  UnionFind<Val*> extent_partition(all_extents);
+  id_partition_ =
+      std::unique_ptr<UnionFind<IterDomain*>>(new UnionFind(all_ids_));
+  extent_partition_ =
+      std::unique_ptr<UnionFind<Val*>>(new UnionFind(all_extents_));
 
-  for (auto expr: fusion.unordered_exprs()) {
+  for (auto expr : fusion.unordered_exprs()) {
     // Expressions fall into one of the following categories:
     //   Broadcast
     //   Reduction
@@ -161,8 +46,9 @@ IterDomainEGraph::IterDomainEGraph(const Fusion& fusion) {
         }
         auto idin = indom[j++];
         auto idout = outdom[i];
-        id_partition.merge_sets_from_values(idin, idout);
-        extent_partition.merge_sets_from_values(idin->extent(), idout->extent());
+        id_partition_->merge_sets_from_values(idin, idout);
+        extent_partition_->merge_sets_from_values(
+            idin->extent(), idout->extent());
       }
     } else if (expr->isA<ReductionOp>()) {
       std::cout << "Reduction op: " << expr->toString() << std::endl;
@@ -185,8 +71,9 @@ IterDomainEGraph::IterDomainEGraph(const Fusion& fusion) {
           // TODO: set RESOLVES relation
           continue;
         }
-        id_partition.merge_sets_from_values(idin, idout);
-        extent_partition.merge_sets_from_values(idin->extent(), idout->extent());
+        id_partition_->merge_sets_from_values(idin, idout);
+        extent_partition_->merge_sets_from_values(
+            idin->extent(), idout->extent());
       }
     } else if (expr->isA<TransposeOp>()) {
       auto top = reinterpret_cast<TransposeOp*>(expr);
@@ -199,13 +86,14 @@ IterDomainEGraph::IterDomainEGraph(const Fusion& fusion) {
         auto oldi = n2o[i];
         auto idin = indom[oldi];
         auto idout = outdom[i];
-        id_partition.merge_sets_from_values(idin, idout);
-        extent_partition.merge_sets_from_values(idin->extent(), idout->extent());
+        id_partition_->merge_sets_from_values(idin, idout);
+        extent_partition_->merge_sets_from_values(
+            idin->extent(), idout->extent());
       }
     } else if (expr->isA<ViewOp>()) {
       std::cout << "Skipping reshape op: " << expr->toString() << std::endl;
-    //} else if (expr->isA<ResizeOp>()) { // pending Naoya's recent work
-    // TODO: Work through the list of other ops:
+      //} else if (expr->isA<ResizeOp>()) { // pending Naoya's recent work
+      // TODO: Work through the list of other ops:
       /*
      *FullOp # nothing to do
      *ARangeOp # nothing to do
@@ -245,54 +133,53 @@ IterDomainEGraph::IterDomainEGraph(const Fusion& fusion) {
       //   the broadcast), then we do not merge.
       //   Instead, in this case we add a relation that the e-class of the
       //   output ID _resolves_ the e-class of the input ID.
-      for (auto inp_val: expr->inputs()) {
+      for (auto inp_val : expr->inputs()) {
         if (inp_val->getValType() != ValType::TensorView) {
           continue;
         }
         auto inp = (TensorView*)inp_val;
         auto indom = inp->domain()->noReductions();
-        for (auto outp_val: expr->outputs()) {
+        for (auto outp_val : expr->outputs()) {
           if (outp_val->getValType() != ValType::TensorView) {
             continue;
           }
           auto outp = (TensorView*)outp_val;
-          // Reduction domains aren't preserved through pointwise ops, so ignore them
-          // For each non-reduction ID in inp and outp
+          // Reduction domains aren't preserved through pointwise ops, so ignore
+          // them For each non-reduction ID in inp and outp
           auto outdom = outp->domain()->noReductions();
           TORCH_CHECK(
               indom.size() == outdom.size(),
-              "Input and output noReductions domains must have equal length in pointwise op"
-          );
-          for (auto idin=indom.begin(), idout=outdom.begin();
-              idin != indom.end() && idout != outdom.end();
-              idin++, idout++) {
+              "Input and output noReductions domains must have equal length in pointwise op");
+          for (auto idin = indom.begin(), idout = outdom.begin();
+               idin != indom.end() && idout != outdom.end();
+               idin++, idout++) {
             TORCH_CHECK(
-              !(*idout)->isBroadcast(),
-              "Output IterDomains of pointwise ops should not be of broadcast type"
-            );
+                !(*idout)->isBroadcast(),
+                "Output IterDomains of pointwise ops should not be of broadcast type");
             // TODO: check for broadcast IDs in input
             if ((*idin)->isBroadcast()) {
               continue;
             }
-            id_partition.merge_sets_from_values(*idin, *idout);
-            extent_partition.merge_sets_from_values((*idin)->extent(), (*idout)->extent());
+            id_partition_->merge_sets_from_values(*idin, *idout);
+            extent_partition_->merge_sets_from_values(
+                (*idin)->extent(), (*idout)->extent());
           }
         }
       }
     }
   }
   std::cout << "Equivalence classes of IterDomains:" << std::endl;
-  for (auto s: id_partition.get_sets()) {
+  for (auto s : id_partition_->get_sets()) {
     std::cout << "  ";
-    for (auto id: s) {
+    for (auto id : s) {
       std::cout << id->toString() << ", ";
     }
     std::cout << std::endl;
   }
   std::cout << "Equivalence classes of extents:" << std::endl;
-  for (auto s: extent_partition.get_sets()) {
+  for (auto s : extent_partition_->get_sets()) {
     std::cout << "  ";
-    for (auto e: s) {
+    for (auto e : s) {
       std::cout << e->toString() << ", ";
     }
     std::cout << std::endl;

--- a/third_party/nvfuser/csrc/id_e_graph.cpp
+++ b/third_party/nvfuser/csrc/id_e_graph.cpp
@@ -1,0 +1,305 @@
+#include "id_e_graph.h"
+
+#include <deque>
+#include <unordered_map>
+#include <vector>
+
+namespace torch {
+namespace jit {
+namespace fuser {
+namespace cuda {
+
+// A fixed-size tree-based union-find (aka disjoint-set) data structure using
+// subtree sizes instead of ranks.
+// cf. https://en.wikipedia.org/wiki/Disjoint-set_data_structure
+template <typename T>
+class UnionFind {
+ public:
+  UnionFind(size_t size) {
+      value_.resize(size);
+      parent_.resize(size);
+      size_.resize(size);
+      // Initialize with all singletoons
+      for (size_t i = 0; i < size; ++i) {
+        parent_[i] = i;
+        size_[i] = 1;
+      }
+  }
+
+  UnionFind(std::vector<T> vals) : UnionFind(vals.size()) {
+    for (size_t i = 0; i < vals.size(); ++i) {
+      this->set_value(i, vals[i]);
+    }
+  }
+
+  UnionFind(std::unordered_set<T> vals) : UnionFind(vals.size()) {
+    size_t i = 0;
+    for (auto v: vals) {
+      this->set_value(i++, v);
+    }
+  }
+
+  void set_value(int pos, const T& val) {
+    value_[pos] = val;
+    val_to_pos_[val] = pos;
+  }
+  T get_value(int pos) {
+    TORCH_CHECK(
+      pos < value_.size(),
+      "Passed invalid position ", pos, " for UnionFind with ", value_.size(), " entries"
+    );
+    return value_[pos];
+  }
+
+  //! Insert the given value and return the new number of elements
+  size_t insert_value(const T& val) {
+    auto pos = parent_.size();
+    parent_.push_back(pos);
+    size_.push_back(1);
+    val_to_pos_[val] = pos;
+    value_.push_back(val);
+    return pos + 1;
+  }
+
+  //! Find the integer position of val
+  size_t get_position(const T& val) {
+    return val_to_pos_.at(val);
+  }
+
+  //! Get the integer index of the set from given position
+  size_t find_set(size_t v) {
+    if (v == parent_[v])
+      return v;
+    // Note that this step actually updates the tree to point directly to the
+    // root index, meaning subsequent look-ups will not need to recurse.
+    return parent_[v] = find_set(parent_[v]);
+  }
+  //! Get the integer index of the set for a given value
+  size_t find_set_from_value(T val) {
+    return find_set(get_position(val));
+  }
+
+  //! Get all elements in the set with given index (up to O(n^2))
+  std::vector<T> get_set(size_t idx) {
+    std::vector<T> s;
+    for (size_t i = 0; i < parent_.size(); ++i) {
+      if (find_set(i) == idx) {
+        s.push_back(value_.at(i));
+      }
+    }
+    return s;
+  }
+
+  //! Get a vector of all sets of values
+  std::vector<std::vector<T>> get_sets() {
+    std::vector<std::vector<T> > out;
+    for (size_t i = 0; i < parent_.size(); ++i) {
+      auto s = get_set(i);
+      if (s.size() > 0) {
+        out.push_back(s);
+      }
+    }
+    return out;
+  }
+
+  //! Merge two sets in the partition
+  void merge_sets(size_t a, size_t b) {
+    if (a != b) {
+      if (size_[a] < size_[b])
+        std::swap(a, b);
+      parent_[b] = a;
+      size_[a] += size_[b];
+    }
+  }
+  //! Merge the sets containing two given values
+  void merge_sets_from_values(T val_a, T val_b) {
+    auto a = find_set(get_position(val_a));
+    auto b = find_set(get_position(val_b));
+    merge_sets(a, b);
+  }
+ private:
+  std::vector<T> value_;
+  std::unordered_map<T, size_t> val_to_pos_;
+  std::vector<size_t> parent_;
+  std::vector<int> size_;
+};
+
+IterDomainEGraph::IterDomainEGraph(const Fusion& fusion) {
+  // Initialize a partition of all IterDomains in the Fusion, initially
+  // containing all singleton classes.
+  std::vector<IterDomain*> all_ids;
+  std::unordered_set<Val*> all_extents; // Also track extents to find which are equivalent
+  for (auto v: fusion.vals()) {
+    if (v->getValType() == ValType::IterDomain) {
+      auto id = reinterpret_cast<IterDomain*>(v);
+      all_ids.push_back(id);
+      all_extents.insert(id->extent());
+    }
+  }
+  UnionFind<IterDomain*> id_partition(all_ids);
+  UnionFind<Val*> extent_partition(all_extents);
+
+  for (auto expr: fusion.unordered_exprs()) {
+    // Expressions fall into one of the following categories:
+    //   Broadcast
+    //   Reduction
+    //   Reshape
+    //   Permute
+    //   Pointwise
+    if (expr->isA<BroadcastOp>()) {
+      std::cout << "Broadcast op: " << expr->toString() << std::endl;
+      auto bop = reinterpret_cast<BroadcastOp*>(expr);
+      auto bcast_flags = bop->getBroadcastDimFlags();
+      auto inp = reinterpret_cast<TensorView*>(bop->in());
+      auto outp = reinterpret_cast<TensorView*>(bop->out());
+      auto indom = inp->domain()->noReductions();
+      auto outdom = outp->domain()->noReductions();
+      for (size_t i = 0, j = 0; i < bcast_flags.size(); ++i) {
+        if (bcast_flags[i]) {
+          // This output dim is a new bcast dimension
+          continue;
+        }
+        auto idin = indom[j++];
+        auto idout = outdom[i];
+        id_partition.merge_sets_from_values(idin, idout);
+        extent_partition.merge_sets_from_values(idin->extent(), idout->extent());
+      }
+    } else if (expr->isA<ReductionOp>()) {
+      std::cout << "Reduction op: " << expr->toString() << std::endl;
+      auto rop = reinterpret_cast<ReductionOp*>(expr);
+      // Instead of flags, we just look at the output type to find reduction
+      // IDs, which will tell us which axes are being reduced over
+      auto inp = reinterpret_cast<TensorView*>(rop->in());
+      auto outp = reinterpret_cast<TensorView*>(rop->out());
+      auto indom = inp->domain()->domain();
+      auto outdom = outp->domain()->domain();
+      for (size_t i = 0; i < indom.size(); ++i) {
+        auto idin = indom[i];
+        auto idout = outdom[i];
+        if (idout->isReduction()) {
+          // Don't merge serial input with rdomain output
+          // TODO: set REDUCES relation
+          continue;
+        }
+        if (idin->isBroadcast()) {
+          // TODO: set RESOLVES relation
+          continue;
+        }
+        id_partition.merge_sets_from_values(idin, idout);
+        extent_partition.merge_sets_from_values(idin->extent(), idout->extent());
+      }
+    } else if (expr->isA<TransposeOp>()) {
+      auto top = reinterpret_cast<TransposeOp*>(expr);
+      auto inp = reinterpret_cast<TensorView*>(top->in());
+      auto outp = reinterpret_cast<TensorView*>(top->out());
+      auto indom = inp->domain()->domain();
+      auto outdom = outp->domain()->domain();
+      auto n2o = top->new2old();
+      for (size_t i = 0; i < outdom.size(); ++i) {
+        auto oldi = n2o[i];
+        auto idin = indom[oldi];
+        auto idout = outdom[i];
+        id_partition.merge_sets_from_values(idin, idout);
+        extent_partition.merge_sets_from_values(idin->extent(), idout->extent());
+      }
+    } else if (expr->isA<ViewOp>()) {
+      std::cout << "Skipping reshape op: " << expr->toString() << std::endl;
+    //} else if (expr->isA<ResizeOp>()) { // pending Naoya's recent work
+    // TODO: Work through the list of other ops:
+      /*
+     *FullOp # nothing to do
+     *ARangeOp # nothing to do
+     *EyeOp # nothing to do
+     *UnaryOp # handled by else
+     *BinaryOp # handled by else
+     *TernaryOp # handled by else
+      SelectOp
+      IndexSelectOp
+      TorchGatherOp
+      RNGOp
+     *ReductionOp
+      GroupedReductionOp
+      WelfordOp
+      GroupedWelfordOp
+      LoadStoreOp
+      MmaOp
+     *BroadcastOp
+      SqueezeOp
+     *TransposeOp
+      ExpandOp
+      ShiftOp
+      GatherOp
+      ViewAsScalar
+      ViewOp
+      Split
+      Merge
+      Swizzle2D
+      */
+    } else {
+      // For pointwise Exprs (or ExpandOp), this is most clear:
+      //   - We simply merge matching (same position, ignoring reduction
+      //   domains) serial IterDomain classes with one another.
+      //   - If the input IterDomain is a bcast and the output Iterdomain is a
+      //   bcast, we merge their e-classes.
+      //   - If the input is a bcast and the output is serial (resolution of
+      //   the broadcast), then we do not merge.
+      //   Instead, in this case we add a relation that the e-class of the
+      //   output ID _resolves_ the e-class of the input ID.
+      for (auto inp_val: expr->inputs()) {
+        if (inp_val->getValType() != ValType::TensorView) {
+          continue;
+        }
+        auto inp = (TensorView*)inp_val;
+        auto indom = inp->domain()->noReductions();
+        for (auto outp_val: expr->outputs()) {
+          if (outp_val->getValType() != ValType::TensorView) {
+            continue;
+          }
+          auto outp = (TensorView*)outp_val;
+          // Reduction domains aren't preserved through pointwise ops, so ignore them
+          // For each non-reduction ID in inp and outp
+          auto outdom = outp->domain()->noReductions();
+          TORCH_CHECK(
+              indom.size() == outdom.size(),
+              "Input and output noReductions domains must have equal length in pointwise op"
+          );
+          for (auto idin=indom.begin(), idout=outdom.begin();
+              idin != indom.end() && idout != outdom.end();
+              idin++, idout++) {
+            TORCH_CHECK(
+              !(*idout)->isBroadcast(),
+              "Output IterDomains of pointwise ops should not be of broadcast type"
+            );
+            // TODO: check for broadcast IDs in input
+            if ((*idin)->isBroadcast()) {
+              continue;
+            }
+            id_partition.merge_sets_from_values(*idin, *idout);
+            extent_partition.merge_sets_from_values((*idin)->extent(), (*idout)->extent());
+          }
+        }
+      }
+    }
+  }
+  std::cout << "Equivalence classes of IterDomains:" << std::endl;
+  for (auto s: id_partition.get_sets()) {
+    std::cout << "  ";
+    for (auto id: s) {
+      std::cout << id->toString() << ", ";
+    }
+    std::cout << std::endl;
+  }
+  std::cout << "Equivalence classes of extents:" << std::endl;
+  for (auto s: extent_partition.get_sets()) {
+    std::cout << "  ";
+    for (auto e: s) {
+      std::cout << e->toString() << ", ";
+    }
+    std::cout << std::endl;
+  }
+}
+
+} // namespace cuda
+} // namespace fuser
+} // namespace jit
+} // namespace torch

--- a/third_party/nvfuser/csrc/id_e_graph.cpp
+++ b/third_party/nvfuser/csrc/id_e_graph.cpp
@@ -170,7 +170,8 @@ void IterDomainEGraph::initGraph() {
   }
   std::cout << "Equivalence classes of IterDomains:" << std::endl;
   for (auto s : id_partition_->getSets()) {
-    std::cout << "  ";
+    std::cout << "  c";
+    std::cout << id_partition_->findSetFromValue(s[0]) << ": ";
     for (auto id : s) {
       std::cout << id->toString() << ", ";
     }
@@ -178,7 +179,8 @@ void IterDomainEGraph::initGraph() {
   }
   std::cout << "Equivalence classes of extents:" << std::endl;
   for (auto s : extent_partition_->getSets()) {
-    std::cout << "  ";
+    std::cout << "  e";
+    std::cout << extent_partition_->findSetFromValue(s[0]) << ": ";
     for (auto e : s) {
       std::cout << e->toString() << ", ";
     }

--- a/third_party/nvfuser/csrc/id_e_graph.h
+++ b/third_party/nvfuser/csrc/id_e_graph.h
@@ -40,22 +40,6 @@ class Relation {
   T left_id_, right_id_;
 };
 
-//! Left domain is inner to right domain in at least one input TensorView
-template <typename T>
-class InnerToInInputRelation : Relation<T> {
-  RelationType type() const {
-    return RelationType::InnerToInInput;
-  }
-};
-
-//! Left domain is inner to right domain in at least one output TensorView
-template <typename T>
-class InnerToInOutputRelation : Relation<T> {
-  RelationType type() const {
-    return RelationType::InnerToInOutput;
-  }
-};
-
 //! Left domain resolves the right (broadcast) domain
 template <typename T>
 class ResolvesBroadcastRelation : Relation<T> {
@@ -75,7 +59,11 @@ class ReducesRelation : Relation<T> {
 //! Implements an E-graph whose "terms" are IterDomains.
 class TORCH_CUDA_CU_API IterDomainEGraph {
  public:
-  IterDomainEGraph(const Fusion& fusion);
+  IterDomainEGraph(Fusion& fusion) : fusion_(fusion) {
+    initGraph();
+  };
+
+  void initGraph();
 
   //! Get all class IDs, which are not guaranteed to be a contiguous list of
   //! size_t's
@@ -84,15 +72,11 @@ class TORCH_CUDA_CU_API IterDomainEGraph {
   //! Convert internal representation to relations over _classes_
   std::vector<Relation<size_t>*> getClassRelations();
 
-  //! Print out a diagram in mermaid format
-  //! https://mermaid.js.org
-  //! https://mermaid.live
-  void printMermaid(std::ostream& stream) {
-    stream << "graph TD" << std::endl;
-  }
+  //! Print out a diagram as a hierarchical graph in GraphViz's .dot format
+  void printDot(std::ostream& stream = std::cout);
 
  private:
-  Fusion* fusion;
+  Fusion& fusion_;
   std::vector<int> e_class_ids_;
   std::vector<Relation<IterDomain*>*> id_relations_;
   std::vector<IterDomain*> all_ids_;

--- a/third_party/nvfuser/csrc/id_e_graph.h
+++ b/third_party/nvfuser/csrc/id_e_graph.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ir_all_nodes.h>
+#include <union_find.h>
 
 #include <memory>
 #include <vector>
@@ -18,21 +19,70 @@ class TORCH_CUDA_CU_API IterDomainENode {
   std::weak_ptr<IterDomain> iter_domain_;
 };
 
-//! Implements an equivalence class of IterDomains.
-class TORCH_CUDA_CU_API IterDomainEClass {
- private:
-  std::vector<IterDomainENode> e_nodes_;
+enum RelationType {
+  ResolvesBroadcast,
+  Reduces,
+  InnerToInInput,
+  InnerToInOutput
+};
+
+//! Abstract class for binary relations
+class Relation {
+ public:
+  Relation(size_t left_id, size_t right_id)
+      : left_id_(left_id), right_id_(right_id){};
+  virtual ~Relation() {}
+  virtual RelationType type() const = 0;
+
+ protected:
+  size_t left_id_, right_id_;
+};
+
+//! Left domain is inner to right domain in at least one input TensorView
+class InnerToInInputRelation : Relation {
+  RelationType type() const {
+    return RelationType::InnerToInInput;
+  }
+};
+
+//! Left domain is inner to right domain in at least one output TensorView
+class InnerToInOutputRelation : Relation {
+  RelationType type() const {
+    return RelationType::InnerToInOutput;
+  }
+};
+
+//! Left domain resolves the right (broadcast) domain
+class ResolvesBroadcastRelation : Relation {
+  RelationType type() const {
+    return RelationType::ResolvesBroadcast;
+  }
+};
+
+//! Left domain is a reduction domain over right domain
+class ReducesRelation : Relation {
+  RelationType type() const {
+    return RelationType::Reduces;
+  }
 };
 
 //! Implements an E-graph whose "terms" are IterDomains.
 class TORCH_CUDA_CU_API IterDomainEGraph {
  public:
-   IterDomainEGraph(const Fusion& fusion);
+  IterDomainEGraph(const Fusion& fusion);
 
+  //! Merge the sets representing two values, preserving relations from each
+  void merge_sets_from_values(const Val* a, const Val* b);
 
  private:
-   Fusion* fusion;
-   std::vector<IterDomainEClass> e_classes_;
+  Fusion* fusion;
+  std::vector<int> e_class_ids_;
+  std::vector<Relation*> relations_;
+  std::vector<IterDomain*> all_ids_;
+  std::unordered_set<Val*>
+      all_extents_; // Also track extents to find which are equivalent
+  std::unique_ptr<UnionFind<IterDomain*>> id_partition_;
+  std::unique_ptr<UnionFind<Val*>> extent_partition_;
 };
 
 } // namespace cuda

--- a/third_party/nvfuser/csrc/id_e_graph.h
+++ b/third_party/nvfuser/csrc/id_e_graph.h
@@ -13,47 +13,41 @@ namespace jit {
 namespace fuser {
 namespace cuda {
 
-class TORCH_CUDA_CU_API IterDomainENode {
- public:
-  IterDomainENode() = default;
+enum RelationType { ResolvesBroadcast, Reduces };
 
- private:
-  std::weak_ptr<IterDomain> iter_domain_;
-};
+std::string printRelationType(RelationType r) {
+  switch (r) {
+    case RelationType::ResolvesBroadcast:
+      return "resolvesBcast";
+    case RelationType::Reduces:
+      return "reduces";
+  }
+  return "";
+}
 
-enum RelationType {
-  ResolvesBroadcast,
-  Reduces,
-  InnerToInInput,
-  InnerToInOutput
-};
-
-//! Abstract class for binary relations
-template <typename T>
 class Relation {
  public:
-  Relation(T left_id, T right_id) : left_id_(left_id), right_id_(right_id){};
-  virtual ~Relation() {}
-  virtual RelationType type() const = 0;
+  Relation(RelationType type, IterDomain* left, IterDomain* right)
+      : type_(type), left_(left), right_(right){};
+
+  IterDomain* getLeft() const {
+    return left_;
+  }
+  IterDomain* getRight() const {
+    return right_;
+  }
+
+  RelationType type() const {
+    return type_;
+  }
+
+  std::string typeString() const {
+    return printRelationType(type());
+  }
 
  protected:
-  T left_id_, right_id_;
-};
-
-//! Left domain resolves the right (broadcast) domain
-template <typename T>
-class ResolvesBroadcastRelation : Relation<T> {
-  RelationType type() const {
-    return RelationType::ResolvesBroadcast;
-  }
-};
-
-//! Left domain is a reduction domain over right domain
-template <typename T>
-class ReducesRelation : Relation<T> {
-  RelationType type() const {
-    return RelationType::Reduces;
-  }
+  RelationType type_;
+  IterDomain *left_, *right_;
 };
 
 //! Implements an E-graph whose "terms" are IterDomains.
@@ -65,20 +59,13 @@ class TORCH_CUDA_CU_API IterDomainEGraph {
 
   void initGraph();
 
-  //! Get all class IDs, which are not guaranteed to be a contiguous list of
-  //! size_t's
-  std::vector<size_t> getClassIds();
-
-  //! Convert internal representation to relations over _classes_
-  std::vector<Relation<size_t>*> getClassRelations();
-
   //! Print out a diagram as a hierarchical graph in GraphViz's .dot format
   void printDot(std::ostream& stream = std::cout);
 
  private:
   Fusion& fusion_;
   std::vector<int> e_class_ids_;
-  std::vector<Relation<IterDomain*>*> id_relations_;
+  std::vector<Relation> id_relations_;
   std::vector<IterDomain*> all_ids_;
   std::unordered_set<Val*>
       all_extents_; // Also track extents to find which are equivalent

--- a/third_party/nvfuser/csrc/id_e_graph.h
+++ b/third_party/nvfuser/csrc/id_e_graph.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <ir_all_nodes.h>
+
+#include <memory>
+#include <vector>
+
+namespace torch {
+namespace jit {
+namespace fuser {
+namespace cuda {
+
+class TORCH_CUDA_CU_API IterDomainENode {
+ public:
+  IterDomainENode() = default;
+
+ private:
+  std::weak_ptr<IterDomain> iter_domain_;
+};
+
+//! Implements an equivalence class of IterDomains.
+class TORCH_CUDA_CU_API IterDomainEClass {
+ private:
+  std::vector<IterDomainENode> e_nodes_;
+};
+
+//! Implements an E-graph whose "terms" are IterDomains.
+class TORCH_CUDA_CU_API IterDomainEGraph {
+ public:
+   IterDomainEGraph(const Fusion& fusion);
+
+
+ private:
+   Fusion* fusion;
+   std::vector<IterDomainEClass> e_classes_;
+};
+
+} // namespace cuda
+} // namespace fuser
+} // namespace jit
+} // namespace torch

--- a/third_party/nvfuser/csrc/id_e_graph.h
+++ b/third_party/nvfuser/csrc/id_e_graph.h
@@ -3,7 +3,9 @@
 #include <ir_all_nodes.h>
 #include <union_find.h>
 
+#include <iostream>
 #include <memory>
+#include <unordered_set>
 #include <vector>
 
 namespace torch {
@@ -27,40 +29,44 @@ enum RelationType {
 };
 
 //! Abstract class for binary relations
+template <typename T>
 class Relation {
  public:
-  Relation(size_t left_id, size_t right_id)
-      : left_id_(left_id), right_id_(right_id){};
+  Relation(T left_id, T right_id) : left_id_(left_id), right_id_(right_id){};
   virtual ~Relation() {}
   virtual RelationType type() const = 0;
 
  protected:
-  size_t left_id_, right_id_;
+  T left_id_, right_id_;
 };
 
 //! Left domain is inner to right domain in at least one input TensorView
-class InnerToInInputRelation : Relation {
+template <typename T>
+class InnerToInInputRelation : Relation<T> {
   RelationType type() const {
     return RelationType::InnerToInInput;
   }
 };
 
 //! Left domain is inner to right domain in at least one output TensorView
-class InnerToInOutputRelation : Relation {
+template <typename T>
+class InnerToInOutputRelation : Relation<T> {
   RelationType type() const {
     return RelationType::InnerToInOutput;
   }
 };
 
 //! Left domain resolves the right (broadcast) domain
-class ResolvesBroadcastRelation : Relation {
+template <typename T>
+class ResolvesBroadcastRelation : Relation<T> {
   RelationType type() const {
     return RelationType::ResolvesBroadcast;
   }
 };
 
 //! Left domain is a reduction domain over right domain
-class ReducesRelation : Relation {
+template <typename T>
+class ReducesRelation : Relation<T> {
   RelationType type() const {
     return RelationType::Reduces;
   }
@@ -71,13 +77,24 @@ class TORCH_CUDA_CU_API IterDomainEGraph {
  public:
   IterDomainEGraph(const Fusion& fusion);
 
-  //! Merge the sets representing two values, preserving relations from each
-  void merge_sets_from_values(const Val* a, const Val* b);
+  //! Get all class IDs, which are not guaranteed to be a contiguous list of
+  //! size_t's
+  std::vector<size_t> getClassIds();
+
+  //! Convert internal representation to relations over _classes_
+  std::vector<Relation<size_t>*> getClassRelations();
+
+  //! Print out a diagram in mermaid format
+  //! https://mermaid.js.org
+  //! https://mermaid.live
+  void printMermaid(std::ostream& stream) {
+    stream << "graph TD" << std::endl;
+  }
 
  private:
   Fusion* fusion;
   std::vector<int> e_class_ids_;
-  std::vector<Relation*> relations_;
+  std::vector<Relation<IterDomain*>*> id_relations_;
   std::vector<IterDomain*> all_ids_;
   std::unordered_set<Val*>
       all_extents_; // Also track extents to find which are equivalent

--- a/third_party/nvfuser/csrc/union_find.h
+++ b/third_party/nvfuser/csrc/union_find.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+namespace torch {
+namespace jit {
+namespace fuser {
+namespace cuda {
+
+//! A tree-based union-find (aka disjoint-set) data structure using ! subtree
+//! sizes instead of ranks.
+//! cf. https://en.wikipedia.org/wiki/Disjoint-set_data_structure
+template <typename T>
+class UnionFind {
+ public:
+  UnionFind(size_t size) {
+    value_.resize(size);
+    parent_.resize(size);
+    size_.resize(size);
+    // Initialize with all singletoons
+    for (size_t i = 0; i < size; ++i) {
+      parent_[i] = i;
+      size_[i] = 1;
+    }
+  }
+
+  UnionFind(std::vector<T> vals) : UnionFind(vals.size()) {
+    for (size_t i = 0; i < vals.size(); ++i) {
+      this->set_value(i, vals[i]);
+    }
+  }
+
+  UnionFind(std::unordered_set<T> vals) : UnionFind(vals.size()) {
+    size_t i = 0;
+    for (auto v : vals) {
+      this->set_value(i++, v);
+    }
+  }
+
+  void set_value(int pos, const T& val) {
+    value_[pos] = val;
+    val_to_pos_[val] = pos;
+  }
+  T get_value(int pos) {
+    TORCH_CHECK(
+        pos < value_.size(),
+        "Passed invalid position ",
+        pos,
+        " for UnionFind with ",
+        value_.size(),
+        " entries");
+    return value_[pos];
+  }
+
+  //! Insert the given value and return the new number of elements
+  size_t insert_value(const T& val) {
+    auto pos = parent_.size();
+    parent_.push_back(pos);
+    size_.push_back(1);
+    val_to_pos_[val] = pos;
+    value_.push_back(val);
+    return pos + 1;
+  }
+
+  //! Find the integer position of val
+  size_t get_position(const T& val) {
+    return val_to_pos_.at(val);
+  }
+
+  //! Get the integer index of the set from given position
+  size_t find_set(size_t v) {
+    if (v == parent_[v])
+      return v;
+    // Note that this step actually updates the tree to point directly to the
+    // root index, meaning subsequent look-ups will not need to recurse.
+    return parent_[v] = find_set(parent_[v]);
+  }
+  //! Get the integer index of the set for a given value
+  size_t find_set_from_value(T val) {
+    return find_set(get_position(val));
+  }
+
+  //! Get all elements in the set with given index (up to O(n^2))
+  std::vector<T> get_set(size_t idx) {
+    std::vector<T> s;
+    for (size_t i = 0; i < parent_.size(); ++i) {
+      if (find_set(i) == idx) {
+        s.push_back(value_.at(i));
+      }
+    }
+    return s;
+  }
+
+  //! Get a vector of all sets of values
+  std::vector<std::vector<T>> get_sets() {
+    std::vector<std::vector<T>> out;
+    for (size_t i = 0; i < parent_.size(); ++i) {
+      auto s = get_set(i);
+      if (s.size() > 0) {
+        out.push_back(s);
+      }
+    }
+    return out;
+  }
+
+  //! Merge two sets in the partition
+  void merge_sets(size_t a, size_t b) {
+    if (a != b) {
+      if (size_[a] < size_[b])
+        std::swap(a, b);
+      parent_[b] = a;
+      size_[a] += size_[b];
+    }
+  }
+  //! Merge the sets containing two given values
+  void merge_sets_from_values(T val_a, T val_b) {
+    auto a = find_set(get_position(val_a));
+    auto b = find_set(get_position(val_b));
+    merge_sets(a, b);
+  }
+
+ private:
+  std::vector<T> value_;
+  std::unordered_map<T, size_t> val_to_pos_;
+  std::vector<size_t> parent_;
+  std::vector<int> size_;
+};
+
+} // namespace cuda
+} // namespace fuser
+} // namespace jit
+} // namespace torch

--- a/third_party/nvfuser/test/test_gpu_id_e_graph.cpp
+++ b/third_party/nvfuser/test/test_gpu_id_e_graph.cpp
@@ -1,0 +1,71 @@
+#if defined(USE_CUDA)
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <arith.h>
+#include <compute_at_map.h>
+#include <executor.h>
+#include <inlining.h>
+#include <ir_all_nodes.h>
+#include <ir_builder.h>
+#include <scheduler/all_schedulers.h>
+#include <id_e_graph.h>
+
+#include <test/cpp/jit/test_utils.h>
+#include <test/test_gpu_validator.h>
+#include <test/test_utils.h>
+
+#include <torch/torch.h>
+
+// Tests go in torch::jit
+namespace torch {
+namespace jit {
+
+using namespace torch::jit::fuser::cuda;
+
+
+// Play with forming equivalence classes of IterDomains
+TEST_F(NVFuserTest, FusionIDEGraph) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+  // [w]
+  //auto tv0 = makeSymbolicTensor(1);
+  auto tv0 = makeConcreteTensor({5});
+  fusion.addInput(tv0);
+
+  // [w, x]
+  auto tv1 = makeSymbolicTensor(2);
+  fusion.addInput(tv1);
+
+  // [w, y]
+  auto tv2 = makeSymbolicTensor(2);
+  fusion.addInput(tv2);
+
+  auto tv3 = set(tv0);
+  // [w]
+  auto tv4 = broadcast(tv3, {false, true});
+  // [w, 1]
+  auto tv5 = add(tv4, tv2);
+  // [w, x]
+  fusion.addOutput(tv5);
+
+  // [w]
+  auto tv6 = broadcast(tv3, {false, true});
+  // [w, 1]
+  auto tv7 = add(tv6, tv2);
+  // [y]
+  fusion.addOutput(tv7);
+
+  auto tv8 = sum(tv1, {0});
+  auto tv9 = add(tv8, tv0);
+  fusion.addOutput(tv9);
+
+  fusion.printMath();
+  //fusion.print();
+
+  IterDomainEGraph eg(fusion);
+}
+
+} // namespace jit
+} // namespace torch
+#endif // #if defined(USE_CUDA)

--- a/third_party/nvfuser/test/test_gpu_id_e_graph.cpp
+++ b/third_party/nvfuser/test/test_gpu_id_e_graph.cpp
@@ -63,6 +63,8 @@ TEST_F(NVFuserTest, FusionIDEGraph) {
   // fusion.print();
 
   IterDomainEGraph eg(fusion);
+
+  eg.printDot();
 }
 
 } // namespace jit

--- a/third_party/nvfuser/test/test_gpu_id_e_graph.cpp
+++ b/third_party/nvfuser/test/test_gpu_id_e_graph.cpp
@@ -5,11 +5,11 @@
 #include <arith.h>
 #include <compute_at_map.h>
 #include <executor.h>
+#include <id_e_graph.h>
 #include <inlining.h>
 #include <ir_all_nodes.h>
 #include <ir_builder.h>
 #include <scheduler/all_schedulers.h>
-#include <id_e_graph.h>
 
 #include <test/cpp/jit/test_utils.h>
 #include <test/test_gpu_validator.h>
@@ -23,13 +23,12 @@ namespace jit {
 
 using namespace torch::jit::fuser::cuda;
 
-
 // Play with forming equivalence classes of IterDomains
 TEST_F(NVFuserTest, FusionIDEGraph) {
   Fusion fusion;
   FusionGuard fg(&fusion);
   // [w]
-  //auto tv0 = makeSymbolicTensor(1);
+  // auto tv0 = makeSymbolicTensor(1);
   auto tv0 = makeConcreteTensor({5});
   fusion.addInput(tv0);
 
@@ -61,7 +60,7 @@ TEST_F(NVFuserTest, FusionIDEGraph) {
   fusion.addOutput(tv9);
 
   fusion.printMath();
-  //fusion.print();
+  // fusion.print();
 
   IterDomainEGraph eg(fusion);
 }

--- a/third_party/nvfuser/test/test_gpu_id_e_graph.cpp
+++ b/third_party/nvfuser/test/test_gpu_id_e_graph.cpp
@@ -68,6 +68,29 @@ TEST_F(NVFuserTest, FusionIDEGraph) {
   eg.printDot();
 }
 
+// Very simple graph with a broadcast and no reductions
+TEST_F(NVFuserTest, FusionSimpleMulIDGraph) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeConcreteTensor({2, 3});
+  fusion.addInput(tv0);
+  auto tv1 = makeConcreteTensor({2});
+  fusion.addInput(tv1);
+
+  auto tv2 = broadcast(tv1, {false, true});
+  auto tv3 = mul(tv0, tv2);
+
+  fusion.addOutput(tv3);
+
+  fusion.printMath();
+  // fusion.print();
+
+  IterDomainEGraph eg(fusion);
+
+  eg.printDot();
+}
+
 // Simple reshape example
 TEST_F(NVFuserTest, FusionReshapeIDGraph) {
   Fusion fusion;


### PR DESCRIPTION
This is an attempt at creating an `IterDomain` graph using manual rules for various `Expr` types. This provides another way to visualize or analyze a `Fusion`. For example, a simple `Fusion` like this
```c++
  auto tv0 = makeConcreteTensor({2, 3});
  fusion.addInput(tv0);
  auto tv1 = makeConcreteTensor({2});
  fusion.addInput(tv1);

  auto tv2 = broadcast(tv1, {false, true});
  auto tv3 = mul(tv0, tv2);

  fusion.addOutput(tv3);
```
can be represented as a TV-centric graph like so:
![image](https://user-images.githubusercontent.com/1454944/223434510-e44deb45-5ab4-45c2-9061-1e3d9000b2e4.png)
or as an ID-centric graph like so:
![image](https://user-images.githubusercontent.com/1454944/223221237-d459419c-822a-41a4-a7bb-3f7fb3388220.png)
where the ID classes above represent the following sets of IDs:
```
Inputs:
  T0_g[ iS0{2}, iS1{3} ], float
  T1_g[ iS2{2} ], float
Outputs:
  T3_g[ iS5{2}, iS6{3} ], float

%kernel_math {
T2_l[ iS3{2}, bS4{1} ]
   = broadcast( T1_g[ iS2{2} ] )
T3_g[ iS5{2}, iS6{3} ]
   = T0_g[ iS0{2}, iS1{3} ]
   * T2_l[ iS3{2}, bS4{1} ];
}

Broadcast op: T2_l[ iS3{2}, bS4{1} ]
   = broadcast( T1_g[ iS2{2} ] )

Equivalence classes of IterDomains:
  c2: bS4{1}, 
  c4: iS5{2}, iS3{2}, iS0{2}, iS2{2}, 
  c5: iS6{3}, iS1{3}, 
Equivalence classes of extents:
  e0: 1, 
  e1: 2, 2, 
  e3: 3, 
```
Clearly this lets us derive some equality constraints on extents, which we also track. So far we do not perform any kind of term rewriting on `Val`s, but we could do so. Also, so far I do not have support for `ViewOp`, or many of the other op types like scatter and gather; unsupported ops are skipped with a warning so in their presence there will be more apparent ID classes than there should be. A challenge in this PR's approach is that for example `ViewOp` does not carry direct information about which input domains are transformed, or even what the original int vector arguments were, which we could use to reconstruct.

## What can we do with ID graphs

ID graphs give us way to pattern match certain cases that we'll need to handle. For example, a Gram matrix computation looks like the following:
```c++
  // [n, d]
  auto tv0 = makeConcreteTensor({5, 7});
  fusion.addInput(tv0);

  // [1, n, d]
  auto tv1 = broadcast(tv0, {true, false, false});
  // [n, 1, d]
  auto tv2 = broadcast(tv0, {false, true, false});

  // [n, n, d]
  auto tv3 = mul(tv1, tv2);

  // [n, n]
  auto tv4 = sum(tv3, {2});

  fusion.addOutput(tv4);
```
![image](https://user-images.githubusercontent.com/1454944/223222290-37ac20da-d56b-4f77-a43a-faf762ffcfbb.png)
We see that two separate output IDs use the same ID class `c7`. This is a problem and indicates we need to recompute class `c7` so that it appears as two classes that can be separately parallelized (note that recomputing is an operation we don't yet support).

We can also infer the ordering of ID classes and persist those back using `reorder()`. We can split and merge domains at the ID class level then persist those as well. Generally, this approach _might_ allow us to transform nodes in our `Fusion` based on groups of ID classes, instead of the current reference tensor approach.